### PR TITLE
Add package building steps to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,20 @@
 ---
 version: 2.1
 
-jobs:
-  build:
+executors:
+  debian:
     docker:
     - image: debian:stable
+  github:
+    docker:
+    - image: cibuilds/github:0.13
+  ruby:
+    docker:
+    - image: circleci/ruby:latest
+
+jobs:
+  build:
+    executor: debian
 
     steps:
     - run: apt-get update
@@ -24,9 +34,33 @@ jobs:
     - store_artifacts:
         path: build
 
+  package:
+    executor: ruby
+
+    steps:
+    - run: install --no-document fpm
+    - checkout
+    - attach_workspace:
+        at: .
+    - run: mkdir -v -p package
+    - run: >
+        fpm -n sproxy -s dir -t deb -a amd64 -v ${CIRCLE_TAG#v} -p package \
+           build/amd64/sproxy=/usr/bin/ \
+           README.md=/usr/share/docs/proxy/
+    - run: >
+        fpm -n sproxy -s dir -t deb -a armhf -v ${CIRCLE_TAG#v} -p package \
+           build/armhf/sproxy=/usr/bin/ \
+           README.md=/usr/share/docs/proxy/
+    - run: >
+        fpm -n sproxy -s dir -t deb -a arm64 -v ${CIRCLE_TAG#v} -p package \
+           build/arm64/sproxy=/usr/bin/ \
+           README.md=/usr/share/docs/proxy/
+    - store_artifacts:
+        path: package
+    # TODO: Add repo publish steps: https://circleci.com/docs/2.0/packagecloud/
+
   release:
-    docker:
-    - image: cibuilds/github:0.13
+    executor: github
 
     steps:
     - run: apk add fakeroot
@@ -54,6 +88,14 @@ workflows:
         filters:
           tags:
             only: /.*/
+    - package:
+        requires:
+        - build
+        filters:
+          tags:
+            only: /^v.*/
+          branches:
+            ignore: /.*/
     - release:
         requires:
         - build

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 sproxy
+# Build pipline dirs
+build
+package
+release


### PR DESCRIPTION
* Add workflow for building and publishing deb packages.
* Use toplevel defined executors.
* Add build artifact dirs to .gitignore.

Signed-off-by: Ben Kochie <superq@gmail.com>